### PR TITLE
Refatoração: Implementação do Mapper e DTO para Missoes

### DIFF
--- a/src/main/java/dev/java10x/CadastroDeNinjas/Missoes/MissoesController.java
+++ b/src/main/java/dev/java10x/CadastroDeNinjas/Missoes/MissoesController.java
@@ -14,22 +14,22 @@ public class MissoesController {
     }
 
     @PostMapping("/criar")
-    public MissoesModel criarMissao(@RequestBody MissoesModel missoes){
+    public MissoesDTO criarMissao(@RequestBody MissoesDTO missoes){
      return missoesService.criarMissoes(missoes);
     }
 
     @GetMapping("/listar")
-    public List<MissoesModel> listarMissoes(){
+    public List<MissoesDTO> listarMissoes(){
         return missoesService.listarMissoes();
     }
 
     @GetMapping("/listar/{id}")
-    public MissoesModel listarMissaoPorId(@PathVariable Long id){
+    public MissoesDTO listarMissaoPorId(@PathVariable Long id){
         return missoesService.listarMissoesPorId(id);
     }
 
     @PutMapping("/alterar/{id}")
-    public MissoesModel alterarMissaoPorId(@PathVariable Long id, @RequestBody MissoesModel missoes){
+    public MissoesDTO alterarMissaoPorId(@PathVariable Long id, @RequestBody MissoesDTO missoes){
         return missoesService.atualizarMissoes(id, missoes);
     }
 

--- a/src/main/java/dev/java10x/CadastroDeNinjas/Missoes/MissoesDTO.java
+++ b/src/main/java/dev/java10x/CadastroDeNinjas/Missoes/MissoesDTO.java
@@ -1,0 +1,18 @@
+package dev.java10x.CadastroDeNinjas.Missoes;
+
+import dev.java10x.CadastroDeNinjas.Ninjas.NinjaModel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MissoesDTO {
+
+    private Long id;
+    private String nome;
+    private String dificuldade;
+    private List<NinjaModel> ninjas;
+}

--- a/src/main/java/dev/java10x/CadastroDeNinjas/Missoes/MissoesMapper.java
+++ b/src/main/java/dev/java10x/CadastroDeNinjas/Missoes/MissoesMapper.java
@@ -1,0 +1,26 @@
+package dev.java10x.CadastroDeNinjas.Missoes;
+
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class MissoesMapper {
+
+    public MissoesModel map(MissoesDTO missoesDTO) {
+        MissoesModel missoesModel = new MissoesModel();
+        missoesModel.setId(missoesDTO.getId());
+        missoesModel.setNome(missoesDTO.getNome());
+        missoesModel.setDificuldade(missoesDTO.getDificuldade());
+        missoesModel.setNinjas(missoesDTO.getNinjas());
+        return missoesModel;
+    }
+
+    public MissoesDTO map(MissoesModel missoesModel) {
+        MissoesDTO missoesDTO = new MissoesDTO();
+        missoesDTO.setId(missoesModel.getId());
+        missoesDTO.setNome(missoesModel.getNome());
+        missoesDTO.setDificuldade(missoesModel.getDificuldade());
+        missoesDTO.setNinjas(missoesModel.getNinjas());
+        return missoesDTO;
+    }
+}

--- a/src/main/java/dev/java10x/CadastroDeNinjas/Missoes/MissoesService.java
+++ b/src/main/java/dev/java10x/CadastroDeNinjas/Missoes/MissoesService.java
@@ -4,37 +4,46 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 public class MissoesService {
 
     private MissoesRepository missoesRepository;
+    private MissoesMapper missoesMapper;
 
-    public MissoesService(MissoesRepository missoesRepository) {
+    public MissoesService(MissoesRepository missoesRepository, MissoesMapper missoesMapper) {
         this.missoesRepository = missoesRepository;
+        this.missoesMapper = missoesMapper;
     }
 
-    public List<MissoesModel> listarMissoes(){
-        return missoesRepository.findAll();
+    public List<MissoesDTO> listarMissoes(){
+        List<MissoesModel> missoes = missoesRepository.findAll();
+        return missoes.stream()
+                .map(missoesMapper::map)
+                .collect(Collectors.toList());
     }
 
-    public MissoesModel listarMissoesPorId(Long id){
+    public MissoesDTO listarMissoesPorId(Long id){
         Optional<MissoesModel> missoesPorId = missoesRepository.findById(id);
-        return missoesPorId.orElse(null);
+        return missoesPorId.map(missoesMapper::map).orElse(null);
     }
 
-    public MissoesModel criarMissoes(MissoesModel missoes){
-        return missoesRepository.save(missoes);
+    public MissoesDTO criarMissoes(MissoesDTO missoesDTO){
+        MissoesModel missoes = missoesMapper.map(missoesDTO);
+        MissoesModel savedMissoes = missoesRepository.save(missoes);
+        return missoesMapper.map(savedMissoes);
     }
 
-    public void deletarMissoesPorId(Long id){
-        missoesRepository.deleteById(id);
-    }
+    public void deletarMissoesPorId(Long id){missoesRepository.deleteById(id);}
 
-    public MissoesModel atualizarMissoes(Long id, MissoesModel missoes){
-        if (missoesRepository.existsById(id)){
-            missoes.setId(id);
-            return missoesRepository.save(missoes);
+    public MissoesDTO atualizarMissoes(Long id, MissoesDTO missoesDTO){
+        Optional<MissoesModel> missoesExistente = missoesRepository.findById(id);
+        if(missoesExistente.isPresent()){
+            MissoesModel missoesAtualizado = missoesMapper.map(missoesDTO);
+            missoesAtualizado.setId(id);
+            MissoesModel missoesSalvo = missoesRepository.save(missoesAtualizado);
+            return missoesMapper.map(missoesSalvo);
         }
         return null;
     }

--- a/src/main/java/dev/java10x/CadastroDeNinjas/Ninjas/NinjaDTO.java
+++ b/src/main/java/dev/java10x/CadastroDeNinjas/Ninjas/NinjaDTO.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.function.Function;
 
 @Data
 @AllArgsConstructor

--- a/src/main/java/dev/java10x/CadastroDeNinjas/Ninjas/NinjaMapper.java
+++ b/src/main/java/dev/java10x/CadastroDeNinjas/Ninjas/NinjaMapper.java
@@ -1,6 +1,5 @@
 package dev.java10x.CadastroDeNinjas.Ninjas;
 
-import dev.java10x.CadastroDeNinjas.Missoes.MissoesModel;
 import org.springframework.stereotype.Component;
 
 @Component


### PR DESCRIPTION
Alterações propostas pelo PR

Implementação do MissoesMapper para conversão entre MissoesModel e MissoesDTO.
Criação do MissoesDTO contendo os campos necessários para comunicação externa.
Refatoração do MissoesService para utilizar o MissoesDTO, eliminando a exposição direta do MissoesModel.
Ajustes no MissoesController para trabalhar com o MissoesDTO, garantindo uma estrutura mais coesa e desacoplada.

Essas mudanças visam melhorar a organização do código e a separação de responsabilidades, facilitando a manutenção e expansão futura da aplicação.